### PR TITLE
disable rollbar in development

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -5,7 +5,7 @@ Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
   # Here we'll disable in 'test':
-  if Rails.env.test?
+  if Rails.env.test? || Rails.env.development?
     config.enabled = false
   end
 


### PR DESCRIPTION
This causes errors for me unless I have a rollbar access token set up, and it was kind of hard to troubleshoot.

I think to make contributing easier you should just disable it by default
